### PR TITLE
Remove comment about unsafe Range() and Reverse()

### DIFF
--- a/lru.go
+++ b/lru.go
@@ -175,7 +175,6 @@ func (lru *LRU) Delete(key interface{}) (prev interface{}, deleted bool) {
 
 // Range iterates over all key/values in the order of most recently to
 // least recently used items.
-// It's not safe to call other LRU operations while ranging.
 func (lru *LRU) Range(iter func(key interface{}, value interface{}) bool) {
 	lru.mu.RLock()
 	defer lru.mu.RUnlock()
@@ -192,7 +191,6 @@ func (lru *LRU) Range(iter func(key interface{}, value interface{}) bool) {
 
 // Reverse iterates over all key/values in the order of least recently to
 // most recently used items.
-// It's not safe to call other LRU operations while ranging.
 func (lru *LRU) Reverse(iter func(key interface{}, value interface{}) bool) {
 	lru.mu.RLock()
 	defer lru.mu.RUnlock()


### PR DESCRIPTION
As far as I can tell, those are indeed thread-safe since https://github.com/tidwall/tinylru/commit/5c2009b6823144f7a414b606d29555d46f5cac91